### PR TITLE
#1 add clear_border and #2 bugfix

### DIFF
--- a/napari_segment_blobs_and_things_with_membranes/_function.py
+++ b/napari_segment_blobs_and_things_with_membranes/_function.py
@@ -15,6 +15,7 @@ from skimage.restoration import rolling_ball
 from napari_tools_menu import register_function
 from skimage.measure import regionprops
 from skimage.segmentation import relabel_sequential
+from skimage.segmentation import clear_border
 
 from skimage import filters
 import scipy
@@ -191,11 +192,37 @@ def binary_invert(binary_image:LabelsData, viewer: napari.Viewer = None) -> Labe
 
 @register_function(menu="Segmentation > Connected component labeling (scikit-image, nsbatwm)")
 @time_slicer
-def connected_component_labeling(binary_image:LabelsData, viewer: napari.Viewer = None) -> LabelsData:
+def connected_component_labeling(binary_image: LabelsData, viewer: napari.Viewer = None,
+                                 exclude_on_edges: bool = False, timelapse: bool = True) -> LabelsData:
     """
     Takes a binary image and produces a label image with all separated objects labeled differently.
+
+    Parameters
+    ----------
+    exclude_on_edges : bool, optional
+        Whether or not to clear objects connected to the label image border/planes (either xy, xz or yz).
+    timelapse: bool, optional
+        Whether or not the image is a timelapse. Important to select if exclude_on_edges is selected. Wrong selection
+        would lead to the incorrect labels removal from borders because time dimension would be also used to construct a
+        border/plane, i.e. labels that appear in the first and last timepoints would be excluded.
     """
-    return label(np.asarray(binary_image))
+    if viewer is not None and timelapse and exclude_on_edges:
+        # processing a 4D-data (3D+time data set)
+        if len(viewer.dims.current_step) == 4:
+            return label(clear_border(np.asarray(binary_image)))
+
+        # in case we process a 3D-data (2D+time data set), current timepoint needs to be read and only x,y data provided
+        # to the clear_border function. Otherwise time dimension would be also used to construct a border/plane
+        elif len(viewer.dims.current_step) == 3:
+            t_position = viewer.dims.current_step[0]
+            return label(clear_border(np.asarray(binary_image[t_position])))
+
+    elif exclude_on_edges:
+        # processing the image, which is not a timelapse
+        return label(clear_border(np.asarray(binary_image)))
+
+    else:
+        return label(np.asarray(binary_image))
 
 
 @register_function(menu="Segmentation > Voronoi-Otsu-labeling (nsbatwm)")

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     scikit-image
     scipy
     napari-tools-menu
+    napari-time-slicer
 
 [options.entry_points] 
 napari.plugin = 


### PR DESCRIPTION
Hi Robert @haesleinhuepf!

I implemented the clear_border function because I was playing around with your plugin, trying to annotate myself more timelapse data (that would be not napari crashing as Lund on my laptop :D ) in order to have more data to work on for my plugin. And I noticed #1, which is a quite useful feature to have.
I tried it out with 2D, 3D+time, 2D+time data and it worked fine besides the known issue of label switching.

![2D+t](https://user-images.githubusercontent.com/52177660/144136021-7ee06ed6-0317-45ba-bc23-88f0bf97b633.gif)

In 3D+time case labels are removed that are connected to the upper and bottom planes:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/52177660/144136032-d897d179-891d-4107-8cfc-3fe3a7358036.gif)

Maybe, it is not the most elegant way to deal with dimensions the way I did, but it took me a bit of time to understand why for some cases It was not working as it should. Let me know what you think!

Also, I have added napari-time-slicer to setup.cfg, which would close #2.