### PR TITLE
add gabor filter

### DIFF
--- a/napari_segment_blobs_and_things_with_membranes/__init__.py
+++ b/napari_segment_blobs_and_things_with_membranes/__init__.py
@@ -22,6 +22,7 @@ import scipy
 from scipy import ndimage
 from napari_time_slicer import time_slicer
 from stackview import jupyter_displayable_output
+from napari.utils import notifications
 
 @napari_hook_implementation
 def napari_experimental_provide_function():
@@ -914,7 +915,8 @@ def gabor(image: "napari.types.ImageData", frequency: float = 10, theta: float =
     from skimage.filters import gabor as \
         sk_gabor
     if len(image.shape) > 2:
-        raise ValueError("Gabor is only supported for 2D images")
+        notifications.show_warning("Gabor is only supported for 2D images")
+        return
     gabor_real, gabor_imag = sk_gabor(image,
              frequency=frequency,
              theta=theta,

--- a/napari_segment_blobs_and_things_with_membranes/__init__.py
+++ b/napari_segment_blobs_and_things_with_membranes/__init__.py
@@ -913,11 +913,14 @@ def gabor(image: "napari.types.ImageData", frequency: float = 10, theta: float =
     """
     from skimage.filters import gabor as \
         sk_gabor
-
-    return sk_gabor(image,
+    if len(image.shape) > 2:
+        raise ValueError("Gabor is only supported for 2D images")
+    gabor_real, gabor_imag = sk_gabor(image,
              frequency=frequency,
              theta=theta,
              bandwidth=bandwidth,
              offset=offset,
              mode='reflect',
              cval=0)
+    # Returns magnitude
+    return np.sqrt(gabor_real**2 + gabor_imag**2)

--- a/napari_segment_blobs_and_things_with_membranes/__init__.py
+++ b/napari_segment_blobs_and_things_with_membranes/__init__.py
@@ -60,7 +60,8 @@ def napari_experimental_provide_function():
         Manually_split_labels,
         rescale,
         resize,
-        extract_slice
+        extract_slice,
+        gabor
     ]
 
 
@@ -897,3 +898,26 @@ def extract_slice(image:"napari.types.ImageData", slice_index:int = 0, axis:int 
     ..[0] https://numpy.org/doc/stable/reference/generated/numpy.take.html
     """
     return np.take(image, slice_index, axis=axis)
+
+
+@register_function(menu="Filtering > Gabor (scikit-image, nsbatwm)")
+@jupyter_displayable_output(library_name='nsbatwm', help_url='https://www.napari-hub.org/plugins/napari-segment-blobs-and-things-with-membranes')
+@time_slicer
+def gabor(image: "napari.types.ImageData", frequency: float = 10, theta: float = 0, bandwidth: float = 1, offset: float = 0) -> "napari.types.ImageData":
+    """
+    The Gabor filter is useful for enhancing spatially oriented patterns and textures.
+
+    See also
+    --------
+    https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.gabor
+    """
+    from skimage.filters import gabor as \
+        sk_gabor
+
+    return sk_gabor(image,
+             frequency=frequency,
+             theta=theta,
+             bandwidth=bandwidth,
+             offset=offset,
+             mode='reflect',
+             cval=0)


### PR DESCRIPTION
Hi Marcelo @zoccoler,

this adds the Gabor filter and closes #18 

Before merging it, I would like to fix some little things. At the moment, the filter produces an image of 3 dimensions out of an image of 2 dimensions and I presume that's not intentional. I'm also not sure about a use-case. The filter applied to blobs looks like this:

![image](https://user-images.githubusercontent.com/12660498/220990704-81abb98b-4943-442e-abdb-ad1aaa2e5de5.png)


When applying it to a 3D image, there is an error telling: `ValueError: The parameter `image` must be a 2-dimensional array`

I'm curious, what could one do with the Gabor filter?

Thanks!

Best,
Robert