### PR TITLE
Add gabor filter

### DIFF
--- a/napari_segment_blobs_and_things_with_membranes/__init__.py
+++ b/napari_segment_blobs_and_things_with_membranes/__init__.py
@@ -22,6 +22,7 @@ import scipy
 from scipy import ndimage
 from napari_time_slicer import time_slicer
 from stackview import jupyter_displayable_output
+from napari.utils import notifications
 
 @napari_hook_implementation
 def napari_experimental_provide_function():
@@ -914,7 +915,8 @@ def gabor(image: "napari.types.ImageData", frequency: float = 10, theta: float =
     from skimage.filters import gabor as \
         sk_gabor
     if len(image.shape) > 2:
-        raise ValueError("Gabor is only supported for 2D images")
+        notifications.show_warning("Gabor is only supported for 2D images")
+        return
     gabor_real, gabor_imag = sk_gabor(image,
              frequency=frequency,
              theta=theta,

--- a/napari_segment_blobs_and_things_with_membranes/__init__.py
+++ b/napari_segment_blobs_and_things_with_membranes/__init__.py
@@ -913,11 +913,14 @@ def gabor(image: "napari.types.ImageData", frequency: float = 10, theta: float =
     """
     from skimage.filters import gabor as \
         sk_gabor
-
-    return sk_gabor(image,
+    if len(image.shape) > 2:
+        raise ValueError("Gabor is only supported for 2D images")
+    gabor_real, gabor_imag = sk_gabor(image,
              frequency=frequency,
              theta=theta,
              bandwidth=bandwidth,
              offset=offset,
              mode='reflect',
              cval=0)
+    # Returns magnitude
+    return np.sqrt(gabor_real**2 + gabor_imag**2)


### PR DESCRIPTION
Hi Robert @haesleinhuepf ,

Thanks for looking into this!
Gabor filters can be used as edge detectors with the advantage that you can change the spatial frequency and the angle that these edges show up. Most use cases I saw are to generate features.
I recommend watching [this video](https://www.youtube.com/watch?v=QEz4bG9P3Qs&ab_channel=DigitalSreeni) from Sreeni where he explains it better in detail, even though using opencv. Also, I added a link to an example from scikit-image in #18 .

It is a complex filter, and the scikit-image implementation returns a tuple with real and imaginary parts. I suggest either creating two wrappers like gabor_real and gabor_imag or return the magnitude (which are my proposed changes). One could also additionally return the phase.

Unfortunately, the [scikit-image implementation](https://scikit-image.org/docs/stable/api/skimage.filters.html#gabor) only works for 2D images right now. There is an [open issue to extend that to 3D](https://github.com/scikit-image/scikit-image/issues/2704).

The blobs may not be the best example to highlight this filter potential, however, if you change the spatial frequency and theta, you can start to see angled patterns (the image below already returns just the magnitude, not the real and imaginary parts). I decreased the spatial frequency below 1.

![image](https://user-images.githubusercontent.com/26173597/221367416-dd212a66-25a2-4bf0-8fba-aed1cef55ba3.png)

With the bricks image, the potential of this filter should be more evident. I also find the `sigma_x` and `sigma_y` parameters more intuitive than the `bandwidth`, maybe we could change that.